### PR TITLE
Save duplicate requests to SQL not working (option -a)

### DIFF
--- a/probeSniffer.py
+++ b/probeSniffer.py
@@ -233,7 +233,7 @@ def packetHandler(pkt):
                     if saveDuplicates:
                         debug("saveDuplicates on")
                         debug("saving to sql")
-                        saveToMYSQL(mac_address, vendor, ssid, rssi_val)
+                        saveToMYSQL(mac_address, vendor, ssid, rssi_val, bssid)
                         debug("saved to sql")
                     if showDuplicates:
                         debug("duplicate")


### PR DESCRIPTION
Fix the save duplicate requests to SQL option